### PR TITLE
Add artifact-metadata permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ on:
 # option 1: full syntax
 permissions:
   actions: read | write | none
+  artifact-metadata: read | write | none
   attestations: read | write | none
   checks: read | write | none
   contents: read | write | none


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file by adding documentation for the `artifact-metadata` permission option under the `permissions` section.