### PR TITLE
Clarify optional properties in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,8 @@ jobs:
     # option 2 - specify environment name and url
     environment:
       name: envName
-      url: someUrl
+      url: someUrl # optional
+      deployment: true # optional, default: true. setting to false will not create a deployment object, not compatible with custom deployment protection rules
 ```
 - `envName` can be a string or any expression (except for the `secrets` context)
 

--- a/README.md
+++ b/README.md
@@ -623,6 +623,19 @@ jobs:
 
 ---
 
+# Expressions
+[Documentation - Evaluate expressions in workflows and actions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions)
+
+### `case` expression
+
+```
+case( pred1, val1, pred2, val2, ..., default )
+```
+
+- Evaluates predicates in order and returns the value corresponding to the first predicate that evaluates to true. If no predicate matches, it returns the last argument as the default value.
+
+---
+
 # Links
 - official github actions: https://github.com/orgs/actions/repositories
 - official azure actions: https://github.com/marketplace?query=Azure&type=actions&verification=verified_creator


### PR DESCRIPTION
This pull request updates the `README.md` to clarify deployment configuration options and adds documentation for a new `case` expression helper in workflow expressions. The most important changes are:

Deployment configuration documentation:

* Clarified that the `url` field under `environment` is optional and documented the new `deployment` field, which controls whether a deployment object is created. Also noted that setting `deployment: false` is not compatible with custom deployment protection rules.

Expression helper documentation:

* Added a new section describing the `case` expression, including usage, behavior, and a link to official documentation on evaluating expressions in workflows and actions.